### PR TITLE
Extend class `Bitmap` with additional functionality.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,13 @@ declare module 'bitbob' {
      */
     clear(): void
     /**
+     *  Clears a field of flags at once (0 counting).
+     *
+     *  @param start - starting bit position.
+     *  @param end - ending bit position.
+     */
+    clearRange(start: number, end: number): void
+    /**
      *  Flips the entire state.
      */
     flip(): void
@@ -28,6 +35,15 @@ declare module 'bitbob' {
      *  @param end - ending bit position.
      */
     flipRange(start: number, end: number): void
+    /**
+     *  Checks if at least one flag of the given mask is set.
+     *
+     *  This is an equivalent to checking multiple `OR` operations at once.
+     *
+     *  @param mask - possible flags to check.
+     *  @returns `true`, if at least one flag is set, otherwise `false`.
+     */
+    has(mask: number): boolean
     /**
      *  Checks if a specific subset of a state is met.
      *
@@ -49,6 +65,13 @@ declare module 'bitbob' {
      */
     set(bit: number): void
     /**
+     *  Sets a field of flags at once (0 counting).
+     *
+     *  @param start - starting bit position.
+     *  @param end - ending bit position.
+     */
+    setRange(start: number, end: number): void
+    /**
      *  Gets the current state of the bitmap.
      */
     get state(): number
@@ -66,6 +89,12 @@ declare module 'bitbob' {
      *  @param bit - the flag to toggle.
      */
     toggle(bit: number): void
+    /**
+     *  Converts the bitmap to a json-viable string.
+     *
+     *  @returns a json-viables string in form of hte current inner state.
+     */
+    toJSON(): string
     /**
      *  Unsets a specific flag.
      *

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "size-limit": "^11.2.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
-  }
+  },
+  "packageManager": "pnpm@10.6.4+sha512.da3d715bfd22a9a105e6e8088cfc7826699332ded60c423b14ec613a185f1602206702ff0fe4c438cb15c979081ce4cb02568e364b15174503a63c7a8e2a5f6c"
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,5 @@
     "size-limit": "^11.2.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
-  },
-  "packageManager": "pnpm@10.6.4+sha512.da3d715bfd22a9a105e6e8088cfc7826699332ded60c423b14ec613a185f1602206702ff0fe4c438cb15c979081ce4cb02568e364b15174503a63c7a8e2a5f6c"
+  }
 }

--- a/src/classes/Bitmap.ts
+++ b/src/classes/Bitmap.ts
@@ -29,9 +29,9 @@ export default class Bitmap {
 
   /**
    *  Clears a field of flags at once (0 counting).
-   * 
-   * @param start - starting bit position.
-   * @param end - ending bit position.
+   *
+   *  @param start - starting bit position.
+   *  @param end - ending bit position.
    */
   clearRange(start: number, end: number): void {
     this.#map &= ~(((2 << ((end - start) - 1)) - 1) << start)
@@ -59,8 +59,8 @@ export default class Bitmap {
    *
    *  This is an equivalent to checking multiple `OR` operations at once.
    *
-   * @param mask - possible flags to check.
-   * @returns `true`, if at least one flag is set, otherwise `false`.
+   *  @param mask - possible flags to check.
+   *  @returns `true`, if at least one flag is set, otherwise `false`.
    */
   has(mask: number): boolean {
     return !!(this.#map & mask)
@@ -95,6 +95,16 @@ export default class Bitmap {
    */
   set(bit: number): void {
     this.#map |= 1 << bit
+  }
+
+  /**
+   *  Sets a field of flags at once (0 counting).
+   *
+   *  @param start - starting bit position.
+   *  @param end - ending bit position.
+   */
+  setRange(start: number, end: number): void {
+    this.#map |= (((2 << ((end - start) - 1)) - 1) << start)
   }
 
   /**

--- a/src/classes/Bitmap.ts
+++ b/src/classes/Bitmap.ts
@@ -114,4 +114,13 @@ export default class Bitmap {
   unset(bit: number): void {
     this.#map &= ~(1 << bit)
   }
+
+  /**
+   *  Converts the bitmap to a json-viable string.
+   *
+   *  @returns a json-viables string in form of hte current inner state.
+   */
+  toJSON(): string {
+    return `{ state: ${this.#map} }`
+  }
 }

--- a/src/classes/Bitmap.ts
+++ b/src/classes/Bitmap.ts
@@ -34,7 +34,7 @@ export default class Bitmap {
    *  @param end - ending bit position.
    */
   clearRange(start: number, end: number): void {
-    this.#map &= ~(((2 << ((end - start) - 1)) - 1) << start)
+    this.#map &= ~(((2 << (end - start - 1)) - 1) << start)
   }
 
   /**
@@ -68,7 +68,7 @@ export default class Bitmap {
 
   /**
    *  Checks if a specific subset of a state is met.
-   * 
+   *
    *  This is an equivalent to checking multiple `AND` operations at once.
    *
    *  @param mask - subset condition
@@ -104,7 +104,7 @@ export default class Bitmap {
    *  @param end - ending bit position.
    */
   setRange(start: number, end: number): void {
-    this.#map |= (((2 << ((end - start) - 1)) - 1) << start)
+    this.#map |= ((2 << (end - start - 1)) - 1) << start
   }
 
   /**

--- a/src/classes/Bitmap.ts
+++ b/src/classes/Bitmap.ts
@@ -21,14 +21,24 @@ export default class Bitmap {
   }
 
   /**
-   *  Clears the entire cached state
+   *  Clears the entire cached state.
    */
   clear(): void {
     this.#map = 0
   }
 
   /**
-   *  Flips the entire state
+   *  Clears a field of flags at once (0 counting).
+   * 
+   * @param start - starting bit position.
+   * @param end - ending bit position.
+   */
+  clearRange(start: number, end: number): void {
+    this.#map &= ~(((2 << ((end - start) - 1)) - 1) << start)
+  }
+
+  /**
+   *  Flips the entire state.
    */
   flip(): void {
     this.#map = ~this.#map & ((1 << 31) - 1)
@@ -37,8 +47,8 @@ export default class Bitmap {
   /**
    *  Flips a field of flags at once (0 counting).
    *
-   *  @param start - starting bit position
-   *  @param end - ending bit position
+   *  @param start - starting bit position.
+   *  @param end - ending bit position.
    */
   flipRange(start: number, end: number): void {
     this.#map ^= ((1 << (end - start + 1)) - 1) << start

--- a/src/classes/Bitmap.ts
+++ b/src/classes/Bitmap.ts
@@ -45,7 +45,21 @@ export default class Bitmap {
   }
 
   /**
+   *  Checks if at least one flag of the given mask is set.
+   *
+   *  This is an equivalent to checking multiple `OR` operations at once.
+   *
+   * @param mask - possible flags to check.
+   * @returns `true`, if at least one flag is set, otherwise `false`.
+   */
+  has(mask: number): boolean {
+    return !!(this.#map & mask)
+  }
+
+  /**
    *  Checks if a specific subset of a state is met.
+   * 
+   *  This is an equivalent to checking multiple `AND` operations at once.
    *
    *  @param mask - subset condition
    *  @returns `true`, if the subset is met, otherwise `false`.

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -91,7 +91,7 @@ describe('Bitmap', () => {
   })
 
   it('flips the entire state map', () => {
-    const bitmap  = createFullBitmap()
+    const bitmap = createFullBitmap()
     bitmap.flip()
     expect(bitmap.state).toBe(0)
 
@@ -129,22 +129,22 @@ describe('Bitmap', () => {
   })
 
   it('can clear a range of flags', () => {
-    const bitmap  = createFullBitmap()
+    const bitmap = createFullBitmap()
     bitmap.clearRange(0, 4)
     expect(bitmap.state).toBe(0b1111111111111111111111111110000)
 
-    const bitmap2  = createFullBitmap()
+    const bitmap2 = createFullBitmap()
     bitmap2.clearRange(2, 7)
     expect(bitmap2.state).toBe(0b1111111111111111111111110000011)
   })
 
   describe('clearRange', () => {
     it('can clear a range of flags', () => {
-      const bitmap  = createFullBitmap()
+      const bitmap = createFullBitmap()
       bitmap.clearRange(0, 4)
       expect(bitmap.state).toBe(0b1111111111111111111111111110000)
 
-      const bitmap2  = createFullBitmap()
+      const bitmap2 = createFullBitmap()
       bitmap2.clearRange(2, 7)
       expect(bitmap2.state).toBe(0b1111111111111111111111110000011)
     })
@@ -172,7 +172,7 @@ describe('Bitmap', () => {
     })
 
     it('does nothing on already set flags', () => {
-      const b1  = createFullBitmap()
+      const b1 = createFullBitmap()
       b1.setRange(0, 4)
       expect(b1.state).toBe(0b1111111111111111111111111111111)
 
@@ -193,7 +193,7 @@ describe('Bitmap', () => {
 
   it('can be converted to json', () => {
     expect(new Bitmap().toJSON()).toBe('{ state: 0 }')
-    
+
     const bitmap = new Bitmap()
     bitmap.set(0)
     bitmap.set(1)

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, test } from 'vitest'
 import Bitmap from '../../src/classes/Bitmap'
 import rotateLeft from '../../src/utils/manipulation/rotateLeft'
 
+function createFullBitmap(): Bitmap {
+  return new Bitmap(0b1111111111111111111111111111111)
+}
+
 describe('Bitmap', () => {
   it('can create', () => {
     expect(() => new Bitmap()).not.toThrowError()
@@ -87,7 +91,7 @@ describe('Bitmap', () => {
   })
 
   it('flips the entire state map', () => {
-    const bitmap = new Bitmap(0b1111111111111111111111111111111)
+    const bitmap  = createFullBitmap()
     bitmap.flip()
     expect(bitmap.state).toBe(0)
 
@@ -125,13 +129,57 @@ describe('Bitmap', () => {
   })
 
   it('can clear a range of flags', () => {
-    const bitmap = new Bitmap(0b1111111111111111111111111111111)
+    const bitmap  = createFullBitmap()
     bitmap.clearRange(0, 4)
     expect(bitmap.state).toBe(0b1111111111111111111111111110000)
 
-    const bitmap2 = new Bitmap(0b1111111111111111111111111111111)
+    const bitmap2  = createFullBitmap()
     bitmap2.clearRange(2, 7)
     expect(bitmap2.state).toBe(0b1111111111111111111111110000011)
+  })
+
+  describe('clearRange', () => {
+    it('can clear a range of flags', () => {
+      const bitmap  = createFullBitmap()
+      bitmap.clearRange(0, 4)
+      expect(bitmap.state).toBe(0b1111111111111111111111111110000)
+
+      const bitmap2  = createFullBitmap()
+      bitmap2.clearRange(2, 7)
+      expect(bitmap2.state).toBe(0b1111111111111111111111110000011)
+    })
+
+    it('does nothing on already cleared flags', () => {
+      const b1 = new Bitmap()
+      b1.clearRange(0, 15)
+      expect(b1.state).toBe(0)
+
+      const b2 = new Bitmap(15) // First 4 bits sets
+      b2.clearRange(5, 8)
+      expect(b2.state).toBe(15) // Shouldn't touch the first 4 bits
+    })
+  })
+
+  describe('setRange', () => {
+    it('can set a range of flags', () => {
+      const b1 = new Bitmap()
+      b1.setRange(0, 4)
+      expect(b1.state).toBe(15)
+
+      const b2 = new Bitmap()
+      b2.setRange(2, 7)
+      expect(b2.state).toBe(124) // 1111100
+    })
+
+    it('does nothing on already set flags', () => {
+      const b1  = createFullBitmap()
+      b1.setRange(0, 4)
+      expect(b1.state).toBe(0b1111111111111111111111111111111)
+
+      const b2 = new Bitmap(0b1111111111111111111111001111100)
+      b2.setRange(2, 7)
+      expect(b2.state).toBe(0b1111111111111111111111001111100) // Shouldn't touch surrounding flags
+    })
   })
 
   test('state can be altered raw', () => {

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -124,6 +124,16 @@ describe('Bitmap', () => {
     expect(bitmap.state).toBe(0)
   })
 
+  it('can clear a range of flags', () => {
+    const bitmap = new Bitmap(0b1111111111111111111111111111111)
+    bitmap.clearRange(0, 4)
+    expect(bitmap.state).toBe(0b1111111111111111111111111110000)
+
+    const bitmap2 = new Bitmap(0b1111111111111111111111111111111)
+    bitmap2.clearRange(2, 7)
+    expect(bitmap2.state).toBe(0b1111111111111111111111110000011)
+  })
+
   test('state can be altered raw', () => {
     const bitmap = new Bitmap()
 

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -123,4 +123,13 @@ describe('Bitmap', () => {
 
     expect(bitmap.state).toBe(0b1010011100)
   })
+
+  it('can be converted to json', () => {
+    expect(new Bitmap().toJSON()).toBe('{ state: 0 }')
+    
+    const bitmap = new Bitmap()
+    bitmap.set(0)
+    bitmap.set(1)
+    expect(bitmap.toJSON()).toBe('{ state: 3 }')
+  })
 })

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -68,13 +68,22 @@ describe('Bitmap', () => {
     expect(bitmap.state).toBe(6)
   })
 
-  it('checks if a subset of a state meets some criteria', () => {
+  it('checks if a subset of a state meets some criteria (AND)', () => {
     const bitmap = new Bitmap()
     bitmap.apply(2 | 4 | 8 | 64 | 256) // 334 -> 101001110
 
     expect(bitmap.isMet(14)).toBe(true) // 14 = 1110 is included in 334
     expect(bitmap.isMet(320)).toBe(true) // 320 = 101000000 is included in 334
     expect(bitmap.isMet(1)).toBe(false)
+  })
+
+  it('checks if at least one flag of the subset is met (OR)', () => {
+    const bitmap = new Bitmap()
+    bitmap.apply(2 | 4 | 8 | 64 | 256)
+
+    expect(bitmap.has(14)).toBe(true) // Check for multiple true
+    expect(bitmap.has(1 | 2)).toBe(true) // 1 is not set, but 2 (10) is set
+    expect(bitmap.has(0)).toBe(false) // 0 is not set
   })
 
   it('flips the entire state map', () => {


### PR DESCRIPTION
I was working on a Nuxt project and came across this package to better manage my state. Unfortunately, Nuxt requires custom classes to have a `toJSON` method for them to be serialized for hydration and SSR as described [here](https://github.com/nuxt/nuxt/issues/21832).

This goal of this PR is to extend the `Bitmap` class to make it compatible with Nuxt and to extend functionality for better manage complex state. It adds:

- `has` to have an `OR` equivalent to the `AND` comparison function `isMet`.
- `clearRange` to clear a field of flags, taking the order of the enum in consideration.
- `setRange` as a `set` equivalent to `clearRange`.