### PR TITLE
Fix: Wrong `get` logic in `Bitmap` class.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,11 @@
 import shiny from 'eslint-config-shiny'
 
-export default await shiny()
+export default [
+    ...await shiny({ configs: ['base', 'format', 'vitest']}),
+    {
+        rules: {
+            'no-underscore-dangle': 0,
+            'unicorn/prefer-at': 0
+        }
+    }
+]

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare module 'bitbob' {
    *
    *   It is recommended to use an `enum` for easier handling of this class.
    */
-  export class Bitmap {
+  export class Bitmap extends BitHandler {
     constructor(initialState?: number)
     /**
      *  Applies a state as a mask to the bitmap.
@@ -81,6 +81,13 @@ declare module 'bitbob' {
      *  @param end - ending bit position.
      */
     flipRange(start: number, end: number): void
+      /**
+       *  Extracts the bit value of the given bit position.
+       *
+       * @param bit - target bit position.
+       * @returns Either `1` for a set state, otherwise `0`.
+       */
+      override get(bit: number): boolean
     /**
      *  Checks if a specific flag (bit) is set.
      *  This also has the ability to check for multiple states at once, acting as an OR operation.
@@ -88,7 +95,7 @@ declare module 'bitbob' {
      *  @param bit - the flag(s) to check.
      *  @returns `true`, if the condition is met, otherwise `false`.
      */
-    has(mask: number): boolean
+    override has(mask: number): boolean
     /**
      *  Checks if a specific subset of a state is met.
      *
@@ -101,7 +108,7 @@ declare module 'bitbob' {
      *
      *  @param bit - the flag to set.
      */
-    set(bit: number): void
+    override set(bit: number): void
     /**
      *  Sets a field of flags at once (0 counting).
      *
@@ -140,7 +147,7 @@ declare module 'bitbob' {
    * Numbers are added from right to left, meaning the more numbers you store, the bigger the state. Each number is assigned to a static
    * field, separated by the pointer start indices. There is the possibility to address more space than currently used.
    */
-  export class ComposedNumber {
+  export class ComposedNumber extends BitHandler {
     constructor(initialState?: number, reserve?: number)
     /**
      * Copies the current `ComposedNumber` into a new one.
@@ -154,14 +161,14 @@ declare module 'bitbob' {
      * @param value - Number to store.
      * @param reserve - Bit length to reserve.
      */
-    set(value: number, reserve?: number): void
+    override set(value: number, reserve?: number): void
     /**
      * Returns the nth number stored inside the composed number.
      *
      * @param id - The nth number.
      * @returns The stored number.
      */
-    get(id: number): number
+    override get(id: number): number
     /**
      * Entirely overwrites the state and pointers of the number.
      *
@@ -188,7 +195,7 @@ declare module 'bitbob' {
      * @param value - Target value.
      * @returns `true` if the store has this value stored, otherwise `false`.
      */
-    has(value: number): boolean
+    override has(value: number): boolean
     /**
      * Finds the index of a stored number.
      *

--- a/package.json
+++ b/package.json
@@ -46,6 +46,5 @@
     "size-limit": "^11.2.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
-  },
-  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "size-limit": "^11.2.0",
     "typescript": "^5.8.2",
     "vitest": "^3.0.9"
-  }
+  },
+  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af"
 }

--- a/src/classes/Bitmap.ts
+++ b/src/classes/Bitmap.ts
@@ -1,3 +1,4 @@
+import { ILog2Sequence } from 'src/constants'
 import BitHandler from './BitHandler'
 
 /**
@@ -50,7 +51,7 @@ export default class Bitmap extends BitHandler {
    * @returns Either `1` for a set state, otherwise `0`.
    */
   override get(bit: number): boolean {
-    return !!((this._state >> (bit >> 1)) & 1)
+    return !!((this._state >>  ILog2Sequence[(bit * 0x04ad19df) >>> 27]) & 1)
   }
 
   /**

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -60,6 +60,26 @@ describe('Bitmap', () => {
       expect(bitmap.get(Test.B)).toBe(true)
       expect(bitmap.get(Test.C)).toBe(true)
     })
+
+    it('works with large states', () => {
+      const bitmap = new Bitmap()
+      const Test = createBitmapStates(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M'])
+
+      bitmap.set(Test.L)
+      bitmap.set(Test.M)
+
+      expect(bitmap.get(Test.A)).toBe(false)
+      expect(bitmap.get(Test.L)).toBe(true)
+      expect(bitmap.get(Test.M)).toBe(true)
+
+      bitmap.toggle(Test.L)
+      bitmap.toggle(Test.M)
+      bitmap.toggle(Test.I)
+
+      expect(bitmap.get(Test.L)).toBe(false)
+      expect(bitmap.get(Test.M)).toBe(false)
+      expect(bitmap.get(Test.I)).toBe(true)
+    })
   })
 
   it('can unset a flag', () => {

--- a/test/classes/Bitmap.test.ts
+++ b/test/classes/Bitmap.test.ts
@@ -61,7 +61,7 @@ describe('Bitmap', () => {
       expect(bitmap.get(Test.C)).toBe(true)
     })
 
-    it('works with large states', () => {
+    it('works with large powers of 2', () => {
       const bitmap = new Bitmap()
       const Test = createBitmapStates(['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M'])
 


### PR DESCRIPTION
Today, I saw that you added my fixes and enhancements to the project. I'm grateful for that. Unfortunately, while I was migrating from `bitbob` 2 to `bitbob` 3, I realized that the `get` function wasn't working correctly. While dividing the power of 2 from the `Bitmap` state does work for the small powers of 2, it doesn't work for large powers like `2048`. Luckily, you've introduced `ILogPow2` in a previous update. Using that makes it work correctly for all powers of 2.